### PR TITLE
feat: add modal/dialog component

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import {
   QueryClientProvider,
 } from "@/app/contexts/ReactQuery";
 import { AppFont } from "@/app/components/AppFont";
+import { ModalContextProvider } from "@/app/contexts/ModalContext/ModalContext";
 
 const App = ({ Component, pageProps }: AppProps) => {
   const [queryClient] = useState(() => ReactQueryClient());
@@ -17,7 +18,9 @@ const App = ({ Component, pageProps }: AppProps) => {
     <>
       <AppFont />
       <QueryClientProvider client={queryClient}>
-        <Component {...pageProps} />
+        <ModalContextProvider>
+          <Component {...pageProps} />
+        </ModalContextProvider>
       </QueryClientProvider>
     </>
   );

--- a/public/icons/x.svg
+++ b/public/icons/x.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M13.5 4.5L4.5 13.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M4.5 4.5L13.5 13.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/app/components/Dialog/Dialog.tsx
+++ b/src/app/components/Dialog/Dialog.tsx
@@ -1,0 +1,52 @@
+import { Dialog as HeadlessDialog } from "@headlessui/react";
+import { ModalProperties, Modal } from "@/app/components/Modal";
+import X from "@/public/icons/x.svg";
+import { Button } from "@/app/components/Button";
+
+interface Properties extends ModalProperties {
+  title: string;
+  closeButtonLabel?: string;
+  continueButtonLabel?: string;
+  onContinue?: () => void;
+  continueDisabled?: boolean;
+}
+
+export const Dialog = ({
+  title,
+  children,
+  onClose,
+  closeButtonLabel = "Close",
+  continueButtonLabel = "Continue",
+  continueDisabled = false,
+  onContinue,
+  ...modalProperties
+}: Properties): JSX.Element => {
+  return (
+    <Modal {...modalProperties} onClose={onClose}>
+      <div className="flex flex-col">
+        <div className="bg-theme-gray-100 flex justify-between items-center px-10 py-5">
+          <HeadlessDialog.Title className=" text-xl text-black font-medium">
+            {title}
+          </HeadlessDialog.Title>
+
+          <button type="button" className="text-black" onClick={onClose}>
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-10 pt-4 pb-10 flex flex-col">
+          <div>{children}</div>
+
+          <div className="flex space-x-3 justify-end">
+            <Button variant="secondary" onClick={onClose}>
+              {closeButtonLabel}
+            </Button>
+            <Button disabled={continueDisabled} onClick={onContinue}>
+              {continueButtonLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/app/components/Dialog/index.tsx
+++ b/src/app/components/Dialog/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Dialog";

--- a/src/app/components/Layout/Layout.tsx
+++ b/src/app/components/Layout/Layout.tsx
@@ -1,9 +1,17 @@
 import { ReactElement } from "react";
+import cn from "classnames";
 import { Navbar } from "@/app/components/Navbar";
+import { useModalContext } from "@/app/contexts/ModalContext/ModalContext";
 
 export const Layout = ({ children }: { children: ReactElement }) => {
+  const { modalOpened } = useModalContext();
+
   return (
-    <div className="flex flex-col">
+    <div
+      className={cn("flex flex-col", {
+        blur: modalOpened,
+      })}
+    >
       <Navbar />
       {children}
     </div>

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -1,0 +1,68 @@
+import { Dialog, Transition } from "@headlessui/react";
+import cn from "classnames";
+
+import { Fragment, useEffect } from "react";
+
+import { useModalContext } from "@/app/contexts/ModalContext/ModalContext";
+
+export interface ModalProperties {
+  children?: React.ReactNode;
+  show?: boolean;
+  onClose: () => void;
+  initialFocus?: React.MutableRefObject<HTMLElement | null>;
+}
+
+export const Modal = ({
+  children,
+  show = false,
+  onClose,
+  initialFocus,
+}: ModalProperties): JSX.Element => {
+  const { setModalOpened } = useModalContext();
+
+  useEffect(() => {
+    setModalOpened(show);
+  }, [show, setModalOpened]);
+
+  return (
+    <Transition show={show} as={Fragment} leave="duration-200">
+      <Dialog
+        as="div"
+        id="modal"
+        className="fixed inset-0 z-50 flex transform items-center overflow-y-auto px-4 py-6 transition-all sm:px-0"
+        onClose={onClose}
+        initialFocus={initialFocus}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="absolute inset-0 bg-[rgba(20,20,20,0.15)]" />
+        </Transition.Child>
+
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          enterTo="opacity-100 translate-y-0 sm:scale-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+          leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        >
+          <Dialog.Panel
+            className={cn(
+              "transform overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:mx-auto w-full max-w-lg",
+            )}
+          >
+            {children}
+          </Dialog.Panel>
+        </Transition.Child>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/src/app/components/Modal/index.tsx
+++ b/src/app/components/Modal/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Modal";

--- a/src/app/contexts/ModalContext/ModalContext.tsx
+++ b/src/app/contexts/ModalContext/ModalContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState } from "react";
+
+interface ContextProperties {
+  setModalOpened: (opened: boolean) => void;
+  modalOpened: boolean;
+}
+
+interface ProviderProperties {
+  children: React.ReactNode;
+}
+
+const ModalContext = createContext<ContextProperties | undefined>(undefined);
+
+export const ModalContextProvider = ({
+  children,
+}: ProviderProperties): JSX.Element => {
+  const [modalOpened, setModalOpened] = useState<boolean>(false);
+
+  return (
+    <ModalContext.Provider
+      value={{
+        modalOpened,
+        setModalOpened,
+      }}
+    >
+      {children}
+    </ModalContext.Provider>
+  );
+};
+
+export const useModalContext = (): ContextProperties => {
+  const context = useContext(ModalContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useModalContext must be used within a ModalContextProvider",
+    );
+  }
+
+  return context;
+};

--- a/src/app/styles/variables.css
+++ b/src/app/styles/variables.css
@@ -58,7 +58,7 @@
   --theme-color-subtle-white: 250 250 250; /* #f8f8f8 */
 
   /* black */
-  --theme-color-black: 46 46 46; /* #333333 */
+  --theme-color-black: 46 46 46; /* #2E2E2E */
 
   /* subtle black */
   --theme-color-subtle-black: 59 59 59; /* #404040 */


### PR DESCRIPTION
Related to https://app.clickup.com/t/86dquumye

Since I need to make the form input components for the send form that will do in a separate pr decided to also create a separate pr with the modal from https://github.com/ArdentHQ/arkconnect-demo/pull/8/files that can be merged in case is needed for another task meanwhile

You can test on the WIP PR -> https://github.com/ArdentHQ/arkconnect-demo/pull/8

Adds the modal, a dialog component and a context used to "blur" the page

- Modal is just an empty modal, and handles stuff like bluring the page (with the context)
- Dialog has more reusable stuff like the actions buttons the title and the close button 