### PR TITLE
feat: dark mode for transactions table

### DIFF
--- a/src/app/components/Label/hooks/useLabelClasses.ts
+++ b/src/app/components/Label/hooks/useLabelClasses.ts
@@ -4,11 +4,11 @@ export const useLabelClasses = ({ variant }: { variant: LabelVariant }) => {
   const base = "rounded-[0.25rem] text-center min-w-[2.5rem] inline-block";
   const padding = "px-1 py-[0.188rem]";
   const colors = {
-    info: "bg-theme-gray-100 text-theme-gray-500 font-medium leading-[125%]",
+    info: "bg-theme-gray-100 text-theme-gray-500 font-medium leading-[125%] dark:bg-theme-gray-700 dark:text-theme-gray-300",
     warning:
-      "bg-theme-warning-100 text-theme-warning-600 font-medium leading-[125%]",
+      "bg-theme-warning-100 text-theme-warning-600 font-medium leading-[125%] dark:bg-transparent dark:text-[#F39B9B] dark:outline dark:outline-[#AA6868]",
     success:
-      "bg-theme-primary-100 text-theme-primary-700 font-medium leading-[125%]",
+      "bg-theme-primary-100 text-theme-primary-700 font-medium leading-[125%] dark:bg-transparent dark:text-theme-primary-600 dark:outline dark:outline-theme-primary-600",
     danger: "bg-theme-error-50 text-theme-error-600 font-medium leading-[125%]",
   };
 

--- a/src/app/components/Link/Link.tsx
+++ b/src/app/components/Link/Link.tsx
@@ -12,7 +12,7 @@ export const Link = ({ href, className, ...properties }: LinkProperties) => {
       href={href}
       {...properties}
       className={twMerge(
-        "text-theme-primary-700 text-sm font-medium leading-[125%] hover:text-theme-primary-600 group hover:underline transition-default focus:outline-none focus:shadow-outline-primary",
+        "text-theme-primary-700 text-sm font-medium leading-[125%] hover:text-theme-primary-600 group hover:underline transition-default focus:outline-none focus:shadow-outline-primary dark:text-theme-primary-600",
         className,
       )}
     />

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -15,7 +15,7 @@ interface TableProperties<T> {
 }
 
 export const TableRow = ({ children }: HTMLAttributes<HTMLTableRowElement>) => (
-  <tr className="border-t border-theme-gray-200 first:border-none">
+  <tr className="border-t border-theme-gray-200 first:border-none dark:border-theme-gray-700">
     {children}
   </tr>
 );
@@ -45,18 +45,18 @@ export function Table<T>({
     <div className="px-6 pb-6">
       <table className="table-auto w-full">
         {!hideHeader && (
-          <thead className="relative before:absolute before:content-[' '] before:h-full before:block before:bg-theme-gray-50 before:-left-6 before:w-6 before:border-t before:border-t-theme-gray-200 after:absolute after:content-[' '] after:h-full after:block after:bg-theme-gray-50 after:-right-6 after:w-6 after:border-t after:border-t-theme-gray-200 after:top-0">
+          <thead className="relative before:absolute before:content-[' '] before:h-full before:block before:bg-theme-gray-50 before:-left-6 before:w-6 before:border-t before:border-t-theme-gray-200 after:absolute after:content-[' '] after:h-full after:block after:bg-theme-gray-50 after:-right-6 after:w-6 after:border-t after:border-t-theme-gray-200 after:top-0 dark:before:bg-theme-gray-700 dark:before:border-t-theme-gray-700 dark:after:bg-theme-gray-700 dark:after:border-t-theme-gray-700">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr
                 key={headerGroup.id}
-                className="bg-theme-gray-50 border-t border-t-theme-gray-200"
+                className="bg-theme-gray-50 border-t border-t-theme-gray-200 dark:border-theme-gray-700 dark:bg-theme-gray-700"
               >
                 {headerGroup.headers.map((header) => {
                   return (
                     <th
                       key={header.id}
                       className={twMerge(
-                        "text-theme-gray-500 text-sm font-medium leading-[125%] py-3",
+                        "text-theme-gray-500 text-sm font-medium leading-[125%] py-3 dark:text-theme-gray-300",
                         // @ts-ignore
                         header.column.columnDef.className as string,
                       )}

--- a/src/domains/transactions/components/Transactions/Transactions.tsx
+++ b/src/domains/transactions/components/Transactions/Transactions.tsx
@@ -24,9 +24,9 @@ export const Transactions = ({ walletData }: { walletData: WalletData }) => {
   });
 
   return (
-    <div className="md:bg-white md:rounded-2.5xl md:mt-6 md:shadow-sm">
+    <div className="md:bg-white md:rounded-2.5xl md:mt-6 md:shadow-sm dark:bg-subtle-black">
       <div className="px-6 py-6 pb-4">
-        <h3 className="break-words md:text-xl md:leading-[1.563rem] font-medium">
+        <h3 className="break-words md:text-xl md:leading-[1.563rem] font-medium dark:text-white">
           {t("LATEST_10_TRANSACTIONS")}
         </h3>
       </div>

--- a/src/domains/transactions/components/TransactionsTable/TransactionTableRow.blocks.tsx
+++ b/src/domains/transactions/components/TransactionsTable/TransactionTableRow.blocks.tsx
@@ -54,7 +54,9 @@ export const TransactionAddress = ({
         <Label variant="warning" className="text-xs">
           {t("TO")}{" "}
         </Label>
-        <span className="text-black text-sm font-medium">{t("Contract")}</span>
+        <span className="text-black text-sm font-medium dark:text-white">
+          {t("Contract")}
+        </span>
       </>
     );
   }

--- a/src/domains/transactions/components/TransactionsTable/TransactionTableRow.tsx
+++ b/src/domains/transactions/components/TransactionsTable/TransactionTableRow.tsx
@@ -44,7 +44,7 @@ export const TransactionTableRow = ({
           </div>
         </TableCell>
 
-        <TableCell className="hidden lg:table-cell text-sm text-black font-medium leading-[125%]">
+        <TableCell className="hidden lg:table-cell text-sm text-black font-medium leading-[125%] dark:text-white">
           {tx.timestamp().timeAgo()}
         </TableCell>
 
@@ -69,7 +69,7 @@ export const TransactionTableRow = ({
         </TableCell>
 
         <TableCell>
-          <div className="flex justify-end text-sm text-black font-medium leading-[125%]">
+          <div className="flex justify-end text-sm text-black font-medium leading-[125%] dark:text-white">
             {tx.fee().toCrypto()}
           </div>
         </TableCell>

--- a/src/domains/transactions/components/TransactionsTable/TransactionsTable.tsx
+++ b/src/domains/transactions/components/TransactionsTable/TransactionsTable.tsx
@@ -50,7 +50,11 @@ export const TransactionsTable = ({
   ];
 
   if (!isTruthy(isLoading) && transactions.length === 0) {
-    return <div className="p-4 text-center">{t("NO_TRANSACTIONS")}</div>;
+    return (
+      <div className="p-4 text-center dark:text-white">
+        {t("NO_TRANSACTIONS")}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] add dark mode to transaction table](https://app.clickup.com/t/86drwcqvh)


## Summary

- Transaction table now fully supports dark mode.
- `Info`, `Success` and `Warning` labels also support dark mode.

<img width="1262" alt="image" src="https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/ea876a34-85b8-414c-8af6-8aa7d976f3fa">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
