### PR TITLE
refactor: dark mode for mobile transactions list

### DIFF
--- a/src/app/components/WalletOverview/WalletOverview.tsx
+++ b/src/app/components/WalletOverview/WalletOverview.tsx
@@ -3,7 +3,7 @@ import { WalletBalance } from "./WalletBalance";
 import { WalletOverviewProperties } from "./WalletOverview.contracts";
 
 export const WalletOverview = (properties: WalletOverviewProperties) => (
-  <div className="bg-white sm:rounded-2.5xl sm:mt-6 sm:shadow-sm dark:bg-subtle-black">
+  <div className="bg-white sm:rounded-2.5xl sm:shadow-sm dark:bg-subtle-black sm:mx-6 mt-6 md:mx-0">
     <div className="flex flex-col lg:flex-row p-1">
       <WalletAddress {...properties} />
       <WalletBalance

--- a/src/domains/transactions/components/Transactions/Transactions.tsx
+++ b/src/domains/transactions/components/Transactions/Transactions.tsx
@@ -25,8 +25,8 @@ export const Transactions = ({ walletData }: { walletData: WalletData }) => {
 
   return (
     <div className="md:bg-white md:rounded-2.5xl md:mt-6 md:shadow-sm dark:md:bg-subtle-black">
-      <div className="px-6 py-6 pb-4">
-        <h3 className="break-words md:text-xl md:leading-[1.563rem] font-medium dark:text-white">
+      <div className="px-6 py-6 pb-4 md:px-0">
+        <h3 className="break-words md:text-xl md:leading-[1.563rem] font-medium dark:text-white md:pl-6">
           {t("LATEST_10_TRANSACTIONS")}
         </h3>
       </div>

--- a/src/domains/transactions/components/TransactionsList/TransactionListItem.tsx
+++ b/src/domains/transactions/components/TransactionsList/TransactionListItem.tsx
@@ -26,8 +26,8 @@ export const TransactionListItem = ({
   const { t } = useTranslation("transactions");
 
   return (
-    <div className="border rounded-2.5xl border-[#d3d3d3] flex flex-col overflow-hidden bg-white">
-      <div className="bg-theme-gray-100 px-4 py-3 justify-between flex">
+    <div className="border rounded-2.5xl border-[#d3d3d3] flex flex-col overflow-hidden bg-white dark:border-theme-gray-700 dark:bg-subtle-black">
+      <div className="bg-theme-gray-100 px-4 py-3 justify-between flex dark:bg-theme-gray-700">
         <Link
           href={tx.explorerLink()}
           target="_blank"
@@ -35,14 +35,14 @@ export const TransactionListItem = ({
         >
           <TruncateMiddle>{tx.id()}</TruncateMiddle>
         </Link>
-        <span className="text-sm text-black font-medium">
+        <span className="text-sm text-black font-medium dark:text-white">
           {tx.timestamp().timeAgo()}
         </span>
       </div>
 
       <div className="pt-3 px-4 pb-4 flex-col flex sm:flex-row justify-between  space-y-5 sm:space-y-0">
         <div className="flex flex-col space-y-2">
-          <span className="text-sm text-theme-gray-500 font-medium">
+          <span className="text-sm text-theme-gray-500 font-medium dark:text-theme-gray-300">
             {tx.isVote() && t("VOTE", { ns: "common" })}
             {tx.isTransfer() && t("TRANSFER", { ns: "common" })}
             {tx.isContract() && t("CONTRACT", { ns: "common" })}
@@ -53,7 +53,7 @@ export const TransactionListItem = ({
           </div>
         </div>
         <div className="flex flex-col space-y-2">
-          <span className="text-sm text-theme-gray-500 font-medium">
+          <span className="text-sm text-theme-gray-500 font-medium dark:text-theme-gray-300">
             {t("VALUE_ARK")}
           </span>
           <div>
@@ -61,11 +61,11 @@ export const TransactionListItem = ({
           </div>
         </div>
         <div className="flex flex-col space-y-2">
-          <span className="text-sm text-theme-gray-500 font-medium">
+          <span className="text-sm text-theme-gray-500 font-medium dark:text-theme-gray-300">
             {t("FEE_ARK")}
           </span>
 
-          <div className="text-sm">{tx.fee().toCrypto()}</div>
+          <div className="text-sm dark:text-white">{tx.fee().toCrypto()}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] add dark mode to mobile table](https://app.clickup.com/t/86drwp4fg)


## Summary

- Paddings for wallet overview and transactions section have been updated to match the design.
- Transactions list fully supports dark mode in mobile view.

<img width="606" alt="image" src="https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/94a2016e-8554-467e-b34c-af95d6133995">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
