### PR TITLE
refactor: dark mode for alerts 

### DIFF
--- a/src/app/components/Alert/Alert.tsx
+++ b/src/app/components/Alert/Alert.tsx
@@ -6,14 +6,14 @@ type AlertProperties = HTMLAttributes<HTMLElement> & {
 
 const AlertSuccess = (properties: HTMLAttributes<HTMLElement>): JSX.Element => (
   <div
-    className="border-t border-theme-primary-600 bg-theme-primary-100 text-theme-primary-700 text-sm px-8 py-3"
+    className="border-t border-theme-primary-600 bg-theme-primary-100 text-theme-primary-700 text-sm px-8 py-3 dark:bg-theme-primary-650/20 dark:text-theme-primary-600 dark:border-theme-primary-650"
     {...properties}
   />
 );
 
 const AlertError = (properties: HTMLAttributes<HTMLElement>): JSX.Element => (
   <div
-    className="border-t border-theme- bg-theme-error-100 text-theme-error-700 text-sm px-8 py-3"
+    className="border-t border-t-theme-error-700 bg-theme-error-100 text-theme-error-700 text-sm px-8 py-3 dark:bg-theme-error-800/20 dark:text-theme-error-500 dark:border-t-theme-error-700"
     {...properties}
   />
 );

--- a/src/app/components/Spinner/Spinner.tsx
+++ b/src/app/components/Spinner/Spinner.tsx
@@ -4,7 +4,7 @@ import SpinnerIcon from "@/public/icons/spinner.svg";
 export const Spinner = ({ className }: { className?: string }) => (
   <SpinnerIcon
     className={twMerge(
-      "animate-spin w-4 text-theme-primary-700 dark:text-primary-650 fill-theme-gray-100 dark:fill-subtle-black",
+      "animate-spin w-4 text-theme-primary-700 dark:text-primary-650 fill-theme-gray-100 dark:fill-theme-gray-700",
       className,
     )}
   />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] add dark mode to error and success states](https://app.clickup.com/t/86drwq1wp)


## Summary

- Background color for spinner's dark mode has been fixed.
- Alert components now supports dark mode for its `success` and `error` statuses.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<img width="617" alt="image" src="https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/ab45b91f-0973-4fd6-adb6-e2d0732a88e0">


<img width="639" alt="image" src="https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/b7da79c2-004e-4806-bc9a-db73e01e8295">



<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
