### PR TITLE
fix: apply background color for body tag in dark mode

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -37,3 +37,7 @@
     @apply pr-[14px]
   }
 }
+
+.dark {
+  @apply bg-subtle-black
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] white edges with blurred background in dark mode](https://app.clickup.com/t/86dt0evqc)

## Summary

- The background color of our body tag now changes from `white` to `subtle-black` for dark mode.
- This will prevent white borders to appear when using blur effects on the background for the modals.

<img width="1509" alt="image" src="https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/015b28e9-b451-4cab-99d5-972ae8b7495a">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
