### PR TITLE
fix: remove scientific notation on number input

### DIFF
--- a/src/domains/transactions/components/SendModal/SendModal.tsx
+++ b/src/domains/transactions/components/SendModal/SendModal.tsx
@@ -2,7 +2,7 @@
 import assert from "assert";
 import { useTranslation } from "next-i18next";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { useEffect } from "react";
+import { FormEvent, useEffect } from "react";
 import { Dialog } from "@/app/components/Dialog";
 import { InputGroup } from "@/app/components/InputGroup";
 import { Input } from "@/app/components/Input";
@@ -132,6 +132,11 @@ export const SendModal = ({
             min="0"
             placeholder="Enter Amount"
             step="0.00000001"
+            onInput={(event: FormEvent<HTMLInputElement>) => {
+              event.currentTarget.value = Number(
+                event.currentTarget.value,
+              ).toFixed(8);
+            }}
             {...register("amount", {
               required: t("AMOUNT_REQUIRED"),
               min: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] remove scientific notation when using arrows](https://app.clickup.com/t/86dt1nw3h)

## Summary

- We now prevent the number input to format the amounts in scientific notation when the have 7 or more decimal digits.

<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/e742afd2-27fe-41f7-9669-c1d2603902c5



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
