### PR TITLE
fix: add secondary button outline

### DIFF
--- a/i18n/locales/en/transactions.json
+++ b/i18n/locales/en/transactions.json
@@ -10,6 +10,7 @@
   "AMOUNT_REQUIRED": "Amount is required",
   "SEND_ARK": "Send ARK",
   "TRANSACTION_FEE": "Transaction Fee",
+  "FEE": "Fee",
   "FEE_IS_REQUIRED": "Fee is required",
   "ADVANCED": "Advanced",
   "SIMPLE": "Simple",

--- a/src/app/components/Button/hooks/useButtonClasses.ts
+++ b/src/app/components/Button/hooks/useButtonClasses.ts
@@ -59,7 +59,7 @@ export const useButtonClasses = ({
   }
 
   const base =
-    "flex justify-center items-center font-bold rounded-2xl whitespace-nowrap space-x-[0.6rem] leading-[1.25rem] transition-default border focus:outline-none focus:ring-2 ring-offset-1 ring-theme-gray-300";
+    "flex justify-center items-center font-bold rounded-2xl whitespace-nowrap space-x-[0.6rem] leading-[1.25rem] transition-default border focus:outline-none focus-visible:ring-2 ring-offset-1 ring-theme-gray-300";
 
   const padding = "py-[0.625rem] px-[1.25rem]";
 

--- a/src/app/components/Button/hooks/useButtonClasses.ts
+++ b/src/app/components/Button/hooks/useButtonClasses.ts
@@ -25,7 +25,7 @@ export const useButtonClasses = ({
     primary:
       "bg-theme-primary-700 text-white border-theme-primary-700 dark:bg-theme-primary-600 dark:border-theme-primary-600",
     secondary:
-      "border border-white bg-white text-theme-primary-700 dark:bg-transparent dark:border-theme-primary-600 dark:text-theme-primary-600 dark:hover:bg-dark-green",
+      "border border-white bg-white text-theme-primary-700 border-theme-primary-700 dark:bg-transparent dark:border-theme-primary-600 dark:text-theme-primary-600 dark:hover:bg-dark-green",
     "secondary-bordered": "border border-white",
     transparent:
       "border-transparent bg-transparent focus-visible:bg-transparent focus-visible:border-theme-primary-700",
@@ -59,7 +59,7 @@ export const useButtonClasses = ({
   }
 
   const base =
-    "flex justify-center items-center font-bold rounded-2xl whitespace-nowrap space-x-[0.6rem] leading-[1.25rem] transition-default border focus:outline-none focus:shadow-outline-primary";
+    "flex justify-center items-center font-bold rounded-2xl whitespace-nowrap space-x-[0.6rem] leading-[1.25rem] transition-default border focus:outline-none focus:ring-2 ring-offset-1 ring-theme-gray-300";
 
   const padding = "py-[0.625rem] px-[1.25rem]";
 

--- a/src/domains/transactions/components/SendModal/SendModal.blocks.tsx
+++ b/src/domains/transactions/components/SendModal/SendModal.blocks.tsx
@@ -50,7 +50,7 @@ export const FeeInput = ({
           >
             {t("SIMPLE")}
           </span>
-          <div className="relative w-9 h-5 bg-theme-primary-700 peer-focus-visible:outline-none peer-focus-visible:ring-4 peer-focus-visible:ring-theme-gray-300 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-theme-primary-700 after:border after:rounded-full after:h-4 after:w-4 after:transition-all"></div>
+          <div className="relative w-9 h-5 bg-theme-primary-700 peer-focus-visible:outline-none peer-focus-visible:ring-2 ring-offset-1 peer-focus-visible:ring-theme-gray-300 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-theme-primary-700 after:border after:rounded-full after:h-4 after:w-4 after:transition-all"></div>
           <span
             className={cn("ms-3 text-sm font-medium", {
               "text-theme-gray-900 dark:text-theme-gray-200": advancedView,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->


## Summary
Closes: https://app.clickup.com/t/86dt3c99x

- adds a border for the cancel button
- adds an outline for the focus state for all buttons
- ensures the fee switch input has the same focus state with buttons
- adds a translation string for the `Fee` label

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
