### PR TITLE
fix: remove scientific notation from amount input

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-i18next": "^13.5.0",
     "react-loading-skeleton": "^3.4.0",
     "react-middle-ellipsis": "^1.2.2",
+    "react-number-format": "^5.3.4",
     "tailwind-merge": "^2.1.0",
     "tailwindcss": "^3.3.6",
     "tippy.js": "^6.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ dependencies:
   react-middle-ellipsis:
     specifier: ^1.2.2
     version: 1.2.2(react-dom@18.2.0)(react@18.2.0)
+  react-number-format:
+    specifier: ^5.3.4
+    version: 5.3.4(react-dom@18.2.0)(react@18.2.0)
   tailwind-merge:
     specifier: ^2.1.0
     version: 2.1.0
@@ -4609,7 +4612,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4693,6 +4695,17 @@ packages:
       react: ^16.8 || ^17 || ^18
       react-dom: ^16.8 || ^17 || ^18
     dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /react-number-format@5.3.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-2hHN5mbLuCDUx19bv0Q8wet67QqYK6xmtLQeY5xx+h7UXiMmRtaCwqko4mMPoKXLc6xAzwRrutg8XbTRlsfjRg==}
+    peerDependencies:
+      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false

--- a/src/app/components/Input/NumericInput.tsx
+++ b/src/app/components/Input/NumericInput.tsx
@@ -27,7 +27,7 @@ export const NumericInput = ({
   value,
   setValue,
   onValueChange,
-  step = 0.000_000_01,
+  step = 0.01,
   variant,
   ...properties
 }: NumericInputProperties) => {

--- a/src/app/components/Input/NumericInput.tsx
+++ b/src/app/components/Input/NumericInput.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import cn from "classnames";
+import {
+  NumericFormat,
+  NumericFormatProps,
+  OnValueChange,
+} from "react-number-format";
+import BigNumber from "bignumber.js";
+import { inputEnabledColorClasses, inputStyleClasses } from "./Input";
+import {
+  InputGroupVariant,
+  useInputGroupContext,
+} from "@/app/components/InputGroup";
+import ArrowUp from "@/public/icons/arrow-up.svg";
+
+interface NumericInputProperties extends NumericFormatProps {
+  visible?: boolean;
+  value?: string;
+  onValueChange: OnValueChange;
+  setValue: (value?: string) => void;
+  step?: number;
+  variant?: InputGroupVariant;
+}
+
+export const NumericInput = ({
+  visible = true,
+  value,
+  setValue,
+  onValueChange,
+  step = 0.000_000_01,
+  variant,
+  ...properties
+}: NumericInputProperties) => {
+  const { groupVariant } = useInputGroupContext();
+  const inputVariant = variant ?? groupVariant ?? "default";
+
+  return (
+    <>
+      <div
+        className={cn("relative w-full h-[52px]", {
+          hidden: !visible,
+          flex: visible,
+        })}
+      >
+        <NumericFormat
+          decimalScale={8}
+          displayType="input"
+          className={cn(
+            "border-theme-gray-400 rounded-l-lg px-3 text-md leading-5 block w-full py-2.5 focus:ring-1 ring-theme-gray-400 rounded-e-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
+            inputEnabledColorClasses[inputVariant],
+            inputStyleClasses,
+          )}
+          value={value}
+          onValueChange={onValueChange}
+          {...properties}
+        />
+        <div className="flex flex-col border border-l-0 dark:border-theme-gray-500 overflow-hidden rounded-e-lg border-theme-gray-400 w-10 shrink-0">
+          <button
+            type="button"
+            onClick={() => {
+              const nextValue = new BigNumber(value || 0).plus(step);
+              const formatted = Number(nextValue.toString()).toFixed(8);
+
+              setValue(new BigNumber(formatted).toFixed());
+            }}
+            className="flex items-center justify-center hover:bg-theme-gray-50 dark:hover:bg-theme-gray-600 basis-1/2 w-full focus:ring-gray-100 focus:ring-2 focus:outline-none relative after:content-[''] after:absolute after:border-t after:bottom-0 after:border-theme-gray-400 after:w-full"
+          >
+            <ArrowUp className="w-2.5 h-2.5 dark:text-white" />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const nextValue = new BigNumber(value || 0).minus(step);
+
+              if (!nextValue.isLessThanOrEqualTo(0)) {
+                const formatted = Number(
+                  nextValue.decimalPlaces(8).toFixed(8),
+                ).toFixed(8);
+
+                setValue(new BigNumber(formatted).toFixed());
+              }
+            }}
+            className="flex items-center relative hover:bg-theme-gray-50 dark:hover:bg-theme-gray-600 justify-center basis-1/2 text-center w-full focus:ring-gray-100 focus:ring-2 focus:outline-none"
+          >
+            <ArrowUp className="w-2.5 h-2.5 rotate-180 dark:text-white" />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/app/components/Input/index.tsx
+++ b/src/app/components/Input/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Input";
+export * from "./NumericInput";

--- a/src/domains/transactions/components/SendModal/SendModal.tsx
+++ b/src/domains/transactions/components/SendModal/SendModal.tsx
@@ -5,7 +5,7 @@ import { SubmitHandler, useForm, UseFormRegisterReturn } from "react-hook-form";
 import React, { useEffect, useState } from "react";
 import { Dialog } from "@/app/components/Dialog";
 import { InputGroup } from "@/app/components/InputGroup";
-import { Input } from "@/app/components/Input";
+import { Input, NumericInput } from "@/app/components/Input";
 import { SignTransactionResponse } from "@/app/lib/Network";
 import { useArkConnectContext } from "@/app/contexts/useArkConnectContext";
 import { FeeInput } from "@/domains/transactions/components/SendModal/SendModal.blocks";
@@ -180,11 +180,27 @@ export const SendModal = ({
           variant={errors.amount?.message ? "error" : undefined}
           help={errors.amount?.message}
         >
-          <Input
-            type="number"
+          <NumericInput
+            decimalScale={8}
             min="0"
+            displayType="input"
             placeholder="Enter Amount"
-            step="0.00000001"
+            value={getValues("amount")}
+            setValue={(value?: string) =>
+              setValue("amount", value ?? "", {
+                shouldValidate: true,
+                shouldTouch: true,
+                shouldDirty: true,
+              })
+            }
+            onValueChange={({ floatValue }: { floatValue?: number }) => {
+              setValue("amount", floatValue?.toString() ?? "", {
+                shouldValidate: true,
+                shouldTouch: true,
+                shouldDirty: true,
+              });
+              void trigger("amount");
+            }}
             {...register("amount", {
               required: t("AMOUNT_REQUIRED"),
               min: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] remove scientific notation when using arrows](https://app.clickup.com/t/86dt1nw3h)

## Summary

- New `NumericInput` component that applies custom styling for arrows.
- Amount input now doesn't display scientific notation when using 7 or more decimal places with the arrows.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/2b712efc-7394-4834-8b33-83a070f24d74

## Steps to reproduce

1. Run `pnpm i` to update our node modules.
2. Then run `pnpm dev`.
3. In the demo site, connect your wallet.
4. Click on `Send` and wait for the modal to open.
5. Use the arrows to increase or decrease the amount value and see the magic ✨ 

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
