### PR TITLE
fix: disable modal when fee is 0

### DIFF
--- a/src/domains/vote/components/VoteModal/VoteModal.tsx
+++ b/src/domains/vote/components/VoteModal/VoteModal.tsx
@@ -130,9 +130,9 @@ export const VoteModal = ({
       onSubmit={handleSubmit}
       title={t("common:VOTE_FOR_DELEGATE")}
       continueDisabled={
-        voteState.votes.length === 0 &&
-        voteState.unvotes.length === 0 &&
-        isValid
+        (voteState.votes.length === 0 && voteState.unvotes.length === 0) ||
+        !isValid ||
+        getValues("fee") === "0"
       }
     >
       <div className="flex flex-col space-y-4">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] disable continue on vote modal when fee is 0](https://app.clickup.com/t/86dt6av06)

## Summary

- `Continue` button is now disabled when fee is set as 0.

<img width="547" alt="image" src="https://github.com/ArdentHQ/arkconnect-demo/assets/55117912/f7016da9-f22e-4853-95ee-986b23735003">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
