### PR TITLE
fix: prevent avg fee from being higher than max

### DIFF
--- a/src/app/hooks/useNetworkFees.ts
+++ b/src/app/hooks/useNetworkFees.ts
@@ -86,11 +86,16 @@ export const useNetworkFees = (network: NetworkType, type: TransactionType) => {
         ? staticFeesData.data["1"].vote
         : staticFeesData.data["1"].transfer;
 
+    const avgFee =
+      BigNumber(dynamicFees.avg).comparedTo(staticFee) > 0
+        ? staticFee
+        : dynamicFees.avg;
+
     return {
       status: "ok",
       fees: {
         min: formatFee(dynamicFees.min, rate),
-        avg: formatFee(dynamicFees.avg, rate),
+        avg: formatFee(avgFee, rate),
         max: formatFee(staticFee, rate),
       },
     };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[demo] prevent slow and average fee from being higher than fast](https://app.clickup.com/t/86dt6yejq)

## Summary

- We now prevent either `min` or `avg` fees from being higher than `max`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked the basic interactions between demo and extension, making sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
